### PR TITLE
build: add conventional commit linter

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,17 @@
+name: "Main Workflow"
+on:
+  pull_request:
+    types:
+      - "opened"
+      - "edited"
+      - "synchronize"
+permissions:
+  pull-requests: "read"
+jobs:
+  main:
+    name: "Validate PR Title"
+    runs-on: "ubuntu-latest"
+    steps:
+      - uses: "amannn/action-semantic-pull-request@v5.4.0"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Resolves #2 

Adds a GitHub Action to lint the titles of pull requests.

The PR will be squashed into the main branch with the conventional commits naming convention.